### PR TITLE
Update conference info on welcome page  and conference page

### DIFF
--- a/lib/pages/flutteristas_conference_page.dart
+++ b/lib/pages/flutteristas_conference_page.dart
@@ -246,8 +246,8 @@ class _FlutteristasConferenceState extends State<FlutteristasConferencePage> {
             //         '${component.conferenceDate} this year. ')
             //     :
             text('The conference took place on '
-                    '${component.conferenceDate} ${component.conferenceYear}, '
-                    'you can still find all the details below.'),
+                '${component.conferenceDate} ${component.conferenceYear}, '
+                'you can still find all the details below.'),
             br(),
             br(),
           ]),

--- a/lib/pages/flutteristas_conference_page.dart
+++ b/lib/pages/flutteristas_conference_page.dart
@@ -230,7 +230,7 @@ class _FlutteristasConferenceState extends State<FlutteristasConferencePage> {
                       classes: 'hero-button',
                       target: Target.blank,
                       href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM',
-                      [text('JOIN US NOW!')])
+                      [text('In case you missed it...')]),
                 ])
               : span([])
         ]),
@@ -240,11 +240,12 @@ class _FlutteristasConferenceState extends State<FlutteristasConferencePage> {
             Text('Greetings, Flutteristas! 💜'),
             br(),
             br(),
-            _selectedYear == _currentYear
-                ? text('Mark your calendars because the highly anticipated Flutteristas Conference '
-                    'is just around the corner, set to take place on '
-                    '${component.conferenceDate} this year. ')
-                : text('The conference took place on '
+            // _selectedYear == _currentYear
+            //     ? text('Mark your calendars because the highly anticipated Flutteristas Conference '
+            //         'is just around the corner, set to take place on '
+            //         '${component.conferenceDate} this year. ')
+            //     :
+            text('The conference took place on '
                     '${component.conferenceDate} ${component.conferenceYear}, '
                     'you can still find all the details below.'),
             br(),

--- a/lib/pages/welcome_page.dart
+++ b/lib/pages/welcome_page.dart
@@ -38,48 +38,25 @@ class WelcomePage extends StatelessComponent {
           br(),
         ]),
         p([
-          img(
-              src: '/images/location_on_FILL0_wght400_GRAD0_opsz24.svg',
-              alt: 'location-icon'),
+          img(src: '/images/location_on_FILL0_wght400_GRAD0_opsz24.svg', alt: 'location-icon'),
           Text(' '),
           a([Text('Youtube Live Stream Recording')],
               href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM'),
-          a([
-            img(
-                src: '/images/external-link-svgrepo-com.svg',
-                alt: 'external-link-icon')
-          ],
-              target: Target.blank,
-              href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM')
+          a([img(src: '/images/external-link-svgrepo-com.svg', alt: 'external-link-icon')],
+              target: Target.blank, href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM')
         ]),
         p([
-          img(
-              src: '/images/tag_FILL0_wght400_GRAD0_opsz24.svg',
-              alt: 'hash-tag-icon'),
+          img(src: '/images/tag_FILL0_wght400_GRAD0_opsz24.svg', alt: 'hash-tag-icon'),
           Text('FlutteristasConf2025 - '),
+          a([img(classes: 'social-icon', src: '/images/x-logo-conf.svg', alt: 'twitter-icon')],
+              target: Target.blank, href: 'https://twitter.com/FlutteristasCon'),
+          a([img(classes: 'social-icon', src: '/images/Mastodon-conf.svg', alt: 'mastodon-icon')],
+              target: Target.blank, href: 'https://fluttercommunity.social/@FlutteristasCon'),
           a([
-            img(
-                classes: 'social-icon',
-                src: '/images/x-logo-conf.svg',
-                alt: 'twitter-icon')
-          ], target: Target.blank, href: 'https://twitter.com/FlutteristasCon'),
-          a([
-            img(
-                classes: 'social-icon',
-                src: '/images/Mastodon-conf.svg',
-                alt: 'mastodon-icon')
+            img(classes: 'social-icon', src: '/images/bluesky-icon-conf.svg', alt: 'facebook-icon')
           ],
               target: Target.blank,
-              href: 'https://fluttercommunity.social/@FlutteristasCon'),
-          a([
-            img(
-                classes: 'social-icon',
-                src: '/images/bluesky-icon-conf.svg',
-                alt: 'facebook-icon')
-          ],
-              target: Target.blank,
-              href:
-                  'https://bsky.app/profile/flutteristascon.flutter.community')
+              href: 'https://bsky.app/profile/flutteristascon.flutter.community')
         ]),
         div(classes: 'buttons-container', [
           a(
@@ -144,20 +121,14 @@ class WelcomePage extends StatelessComponent {
     );
     yield div(classes: 'activities-section', [
       div(classes: 'activities-item', [
-        img(
-            classes: 'activities-icon',
-            src: '/images/4857010.png',
-            alt: 'activities-icon'),
+        img(classes: 'activities-icon', src: '/images/4857010.png', alt: 'activities-icon'),
         h3([text('Meetings')]),
-        p(classes: 'activities-text', [
-          text('Monthly meetings to connect and share news and achievements')
-        ])
+        p(
+            classes: 'activities-text',
+            [text('Monthly meetings to connect and share news and achievements')])
       ]),
       div(classes: 'activities-item', [
-        img(
-            classes: 'activities-icon',
-            src: '/images/6491438.png',
-            alt: 'activities-icon'),
+        img(classes: 'activities-icon', src: '/images/6491438.png', alt: 'activities-icon'),
         h3([text('Meet the Flutter Team')]),
         p(classes: 'activities-text', [
           text(
@@ -165,10 +136,7 @@ class WelcomePage extends StatelessComponent {
         ])
       ]),
       div(classes: 'activities-item', [
-        img(
-            classes: 'activities-icon',
-            src: '/images/4892807.png',
-            alt: 'activities-icon'),
+        img(classes: 'activities-icon', src: '/images/4892807.png', alt: 'activities-icon'),
         h3([text('Volunteering & Experiences')]),
         p(classes: 'activities-text', [
           text(
@@ -176,10 +144,7 @@ class WelcomePage extends StatelessComponent {
         ])
       ]),
       div(classes: 'activities-item', [
-        img(
-            classes: 'activities-icon',
-            src: '/images/7037084.png',
-            alt: 'activities-icon'),
+        img(classes: 'activities-icon', src: '/images/7037084.png', alt: 'activities-icon'),
         h3([text('Speaker\'s training')]),
         p(classes: 'activities-text', [
           text(

--- a/lib/pages/welcome_page.dart
+++ b/lib/pages/welcome_page.dart
@@ -18,39 +18,75 @@ class WelcomePage extends StatelessComponent {
     yield div(classes: 'conference-hero', [
       div(classes: 'conference-title', [
         // p(classes: 'conference-coming-soon', [Text('Coming Soon!')]),
-        h2(classes: 'conference-text', [Text('Flutteristas'), br(), Text('Conference 2025')]),
+        h2(classes: 'conference-text', [
+          Text('Flutteristas Events'),
+          br(),
+        ]),
+        a(
+            classes: 'hero-button',
+            target: Target.blank,
+            href: 'https://www.meetup.com/flutterista/',
+            [text('Get notified of our next event...')])
       ]),
       div(classes: 'conference-details', [
-        p([
-          img(src: '/images/calendar_month_FILL0_wght400_GRAD0_opsz24.svg', alt: 'date-icon'),
-          Text('Date: 5 April 2025 ')
+        h3(classes: 'conference-text', [
+          Text('Our past Flutteristas Conference:'),
+          br(),
         ]),
         p([
-          img(src: '/images/location_on_FILL0_wght400_GRAD0_opsz24.svg', alt: 'location-icon'),
-          Text('Location: '),
-          a([Text('Youtube Live Stream')], href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM'),
-          a([img(src: '/images/external-link-svgrepo-com.svg', alt: 'external-link-icon')],
-              target: Target.blank, href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM')
+          Text(' The conference took place on 5th April 2025.'),
+          br(),
         ]),
         p([
-          img(src: '/images/tag_FILL0_wght400_GRAD0_opsz24.svg', alt: 'hash-tag-icon'),
-          Text('FlutteristasConf2025 - '),
-          a([img(classes: 'social-icon', src: '/images/x-logo-conf.svg', alt: 'twitter-icon')],
-              target: Target.blank, href: 'https://twitter.com/FlutteristasCon'),
-          a([img(classes: 'social-icon', src: '/images/Mastodon-conf.svg', alt: 'mastodon-icon')],
-              target: Target.blank, href: 'https://fluttercommunity.social/@FlutteristasCon'),
+          img(
+              src: '/images/location_on_FILL0_wght400_GRAD0_opsz24.svg',
+              alt: 'location-icon'),
+          Text(' '),
+          a([Text('Youtube Live Stream Recording')],
+              href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM'),
           a([
-            img(classes: 'social-icon', src: '/images/bluesky-icon-conf.svg', alt: 'facebook-icon')
+            img(
+                src: '/images/external-link-svgrepo-com.svg',
+                alt: 'external-link-icon')
           ],
               target: Target.blank,
-              href: 'https://bsky.app/profile/flutteristascon.flutter.community')
+              href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM')
+        ]),
+        p([
+          img(
+              src: '/images/tag_FILL0_wght400_GRAD0_opsz24.svg',
+              alt: 'hash-tag-icon'),
+          Text('FlutteristasConf2025 - '),
+          a([
+            img(
+                classes: 'social-icon',
+                src: '/images/x-logo-conf.svg',
+                alt: 'twitter-icon')
+          ], target: Target.blank, href: 'https://twitter.com/FlutteristasCon'),
+          a([
+            img(
+                classes: 'social-icon',
+                src: '/images/Mastodon-conf.svg',
+                alt: 'mastodon-icon')
+          ],
+              target: Target.blank,
+              href: 'https://fluttercommunity.social/@FlutteristasCon'),
+          a([
+            img(
+                classes: 'social-icon',
+                src: '/images/bluesky-icon-conf.svg',
+                alt: 'facebook-icon')
+          ],
+              target: Target.blank,
+              href:
+                  'https://bsky.app/profile/flutteristascon.flutter.community')
         ]),
         div(classes: 'buttons-container', [
           a(
               classes: 'hero-button',
               target: Target.blank,
               href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM',
-              [text('JOIN US NOW!')]),
+              [text('In case you missed it...')]),
           a(
               classes: 'more-button',
               href: 'https://flutteristas.org/flutteristas-conference/2025'
@@ -108,14 +144,20 @@ class WelcomePage extends StatelessComponent {
     );
     yield div(classes: 'activities-section', [
       div(classes: 'activities-item', [
-        img(classes: 'activities-icon', src: '/images/4857010.png', alt: 'activities-icon'),
+        img(
+            classes: 'activities-icon',
+            src: '/images/4857010.png',
+            alt: 'activities-icon'),
         h3([text('Meetings')]),
-        p(
-            classes: 'activities-text',
-            [text('Monthly meetings to connect and share news and achievements')])
+        p(classes: 'activities-text', [
+          text('Monthly meetings to connect and share news and achievements')
+        ])
       ]),
       div(classes: 'activities-item', [
-        img(classes: 'activities-icon', src: '/images/6491438.png', alt: 'activities-icon'),
+        img(
+            classes: 'activities-icon',
+            src: '/images/6491438.png',
+            alt: 'activities-icon'),
         h3([text('Meet the Flutter Team')]),
         p(classes: 'activities-text', [
           text(
@@ -123,7 +165,10 @@ class WelcomePage extends StatelessComponent {
         ])
       ]),
       div(classes: 'activities-item', [
-        img(classes: 'activities-icon', src: '/images/4892807.png', alt: 'activities-icon'),
+        img(
+            classes: 'activities-icon',
+            src: '/images/4892807.png',
+            alt: 'activities-icon'),
         h3([text('Volunteering & Experiences')]),
         p(classes: 'activities-text', [
           text(
@@ -131,7 +176,10 @@ class WelcomePage extends StatelessComponent {
         ])
       ]),
       div(classes: 'activities-item', [
-        img(classes: 'activities-icon', src: '/images/7037084.png', alt: 'activities-icon'),
+        img(
+            classes: 'activities-icon',
+            src: '/images/7037084.png',
+            alt: 'activities-icon'),
         h3([text('Speaker\'s training')]),
         p(classes: 'activities-text', [
           text(


### PR DESCRIPTION
- On Conference 2025 page: Pulling through now the default text for past conferences.
- On Welcome page: Added link to meetup page, changed wording to reflect that the conference is in the past.

**Please note:**  when using "more details" link on the welcome page it switches to the live website.

To test the wording please use the specific links on the PR:
https://flutteristas.org
and
https://flutteristas.org/flutteristas-conference/2025
