### PR TITLE
Update banners on welcome page and conference page.

### DIFF
--- a/lib/pages/flutteristas_conference_page.dart
+++ b/lib/pages/flutteristas_conference_page.dart
@@ -230,7 +230,7 @@ class _FlutteristasConferenceState extends State<FlutteristasConferencePage> {
                       classes: 'hero-button',
                       target: Target.blank,
                       href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM',
-                      [text('JOIN US NOW!')])
+                      [text('In case you missed it...')])
                 ])
               : span([])
         ]),
@@ -240,13 +240,14 @@ class _FlutteristasConferenceState extends State<FlutteristasConferencePage> {
             Text('Greetings, Flutteristas! 💜'),
             br(),
             br(),
-            _selectedYear == _currentYear
-                ? text('Mark your calendars because the highly anticipated Flutteristas Conference '
-                    'is just around the corner, set to take place on '
-                    '${component.conferenceDate} this year. ')
-                : text('The conference took place on '
-                    '${component.conferenceDate} ${component.conferenceYear}, '
-                    'you can still find all the details below.'),
+            // _selectedYear == _currentYear
+            //     ? text('Mark your calendars because the highly anticipated Flutteristas Conference '
+            //         'is just around the corner, set to take place on '
+            //         '${component.conferenceDate} this year. ')
+            //     :
+            text('The conference took place on '
+                '${component.conferenceDate} ${component.conferenceYear}, '
+                'you can still find all the details below.'),
             br(),
             br(),
           ]),

--- a/lib/pages/welcome_page.dart
+++ b/lib/pages/welcome_page.dart
@@ -18,17 +18,23 @@ class WelcomePage extends StatelessComponent {
     yield div(classes: 'conference-hero', [
       div(classes: 'conference-title', [
         // p(classes: 'conference-coming-soon', [Text('Coming Soon!')]),
-        h2(classes: 'conference-text', [Text('Flutteristas'), br(), Text('Conference 2025')]),
+        h2(classes: 'conference-text', [Text('Flutteristas events'), br()]),
+        a(
+            classes: 'hero-button',
+            target: Target.blank,
+            href: 'https://www.meetup.com/flutterista/',
+            [text('Get notified of our next event...')]),
       ]),
       div(classes: 'conference-details', [
-        p([
-          img(src: '/images/calendar_month_FILL0_wght400_GRAD0_opsz24.svg', alt: 'date-icon'),
-          Text('Date: 5 April 2025 ')
+        h3(classes: 'conference-text', [
+          Text('Our past Flutteristas Conference:'),
+          br(),
         ]),
+        p([Text('The conference took place 5th April 2025')]),
         p([
           img(src: '/images/location_on_FILL0_wght400_GRAD0_opsz24.svg', alt: 'location-icon'),
-          Text('Location: '),
-          a([Text('Youtube Live Stream')], href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM'),
+          Text(' '),
+          a([Text('Youtube Recording')], href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM'),
           a([img(src: '/images/external-link-svgrepo-com.svg', alt: 'external-link-icon')],
               target: Target.blank, href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM')
         ]),
@@ -50,7 +56,7 @@ class WelcomePage extends StatelessComponent {
               classes: 'hero-button',
               target: Target.blank,
               href: 'https://www.youtube.com/watch?v=ftTXXAx8AxM',
-              [text('JOIN US NOW!')]),
+              [text('In case you missed it...')]),
           a(
               classes: 'more-button',
               href: 'https://flutteristas.org/flutteristas-conference/2025'


### PR DESCRIPTION
On Conference 2025 page: Pulling through now the default text for past conferences.
On Welcome page: Added link to meetup page, changed wording to reflect that the conference is in the past.
Please note: when using "more details" link on the welcome page it switches to the live website.

To test the wording please use the specific links on the PR:
https://flutteristas.org/
and
https://flutteristas.org/flutteristas-conference/2025